### PR TITLE
Save source and detector locations for 3D data

### DIFF
--- a/Snirf/ProbeClass.m
+++ b/Snirf/ProbeClass.m
@@ -33,10 +33,17 @@ classdef ProbeClass < FileLoadSaveClass
                     SD = varargin{1};
                     obj.wavelengths = SD.Lambda;
                     obj.wavelengthsEmission  = [];
-                    obj.sourcePos2D  = SD.SrcPos;
-                    obj.detectorPos2D  = SD.DetPos;
-                    obj.sourcePos3D  = [];
-                    obj.detectorPos3D  = [];
+                    if size(SD.SrcPos, 2) == 3 & SD.SrcPos(1, 3) ~= 0
+                        obj.sourcePos3D  = SD.SrcPos;
+                        obj.detectorPos3D  = SD.DetPos;
+                        obj.sourcePos2D  = [];
+                        obj.detectorPos2D  = [];
+                    else
+                        obj.sourcePos2D  = SD.SrcPos;
+                        obj.detectorPos2D  = SD.DetPos;
+                        obj.sourcePos3D  = [];
+                        obj.detectorPos3D  = [];
+                    end
                     obj.frequencies  = 1;
                     obj.timeDelay  = 0;
                     obj.timeDelayWidth  = 0;
@@ -184,8 +191,14 @@ classdef ProbeClass < FileLoadSaveClass
             end     
             hdf5write_safe(fileobj, [location, '/wavelengths'], obj.wavelengths);
             hdf5write_safe(fileobj, [location, '/wavelengthsEmission'], obj.wavelengthsEmission);
-            hdf5write_safe(fileobj, [location, '/sourcePos2D'], obj.sourcePos2D(:,1:2), 'rw:2D');
-            hdf5write_safe(fileobj, [location, '/detectorPos2D'], obj.detectorPos2D(:,1:2), 'rw:2D');
+            if ~isempty(obj.sourcePos2D)
+                hdf5write_safe(fileobj, [location, '/sourcePos2D'], obj.sourcePos2D(:,1:2), 'rw:2D');
+                hdf5write_safe(fileobj, [location, '/detectorPos2D'], obj.detectorPos2D(:,1:2), 'rw:2D');
+            end
+            if ~isempty(obj.sourcePos3D)
+                hdf5write_safe(fileobj, [location, '/sourcePos3D'], obj.sourcePos3D(:,1:3), 'rw:2D');
+                hdf5write_safe(fileobj, [location, '/detectorPos3D'], obj.detectorPos3D(:,1:3), 'rw:2D');
+            end
             hdf5write_safe(fileobj, [location, '/frequencies'], obj.frequencies);
             hdf5write_safe(fileobj, [location, '/timeDelay'], obj.timeDelay);
             hdf5write_safe(fileobj, [location, '/timeDelayWidth'], obj.timeDelayWidth);


### PR DESCRIPTION
This PR addresses the issue described in #5. Please let me know if the current behaviour is expected and I will close that issue and this PR.

This PR stores source and detectors in `obj.detectorPos3D` instead of `obj.detectorPos2D` if 3 dimensions are available. It also writes the 3d variables to disk if they exist.